### PR TITLE
Précision sur les Number

### DIFF
--- a/chapter-02/index.adoc
+++ b/chapter-02/index.adoc
@@ -427,7 +427,7 @@ On peut remplacer les occurrences correspondantes à un masque de caractères vi
 
 ===== Number
 
-Tous les nombres en ECMAScript sont des flottants respectant le standard _IEEE 754_.
+Tous les nombres en ECMAScript sont des flottants (double précision) respectant le standard link:https://fr.wikipedia.org/wiki/IEEE_754[_IEEE 754_].
 Un nombre peut donc contenir 64 bits de données, comme en Python et PHP, entre autres.
 
 L'opérateur `typeof` permet d'identifier un nombre :


### PR DESCRIPTION
Petite précision pour indiquer qu'on parle de "double precision" (il y a plusieurs versions de flottants dans la norme IEEE 754).
Et lien vers la page Wikipédia française expliquant cette norme.

Peut-être faudrait-il aussi mettre une note pour indiquer/rappeler qu'il n'y a pas une "précision" de 64 bits. En effet, ECMAScript n'est pas capable de gérer les Int64 même si les Number ont "64 bits de données". Dans un double 64, la mantisse ne fait que 52 bits (+1 implicite), le reste étant réservé pour l'exposant (11 bits) et le signe (1 bit).
Prendre l'exemple de Twitter avec ses ids : https://dev.twitter.com/overview/api/twitter-ids-json-and-snowflake