### PR TITLE
Précision parseInt parseFloat

### DIFF
--- a/chapter-02/index.adoc
+++ b/chapter-02/index.adoc
@@ -467,10 +467,16 @@ typeof 2.10 === 'number';
 typeof '2.10' === 'string';
 
 parseInt('2.10', 10); <1>
-parseFloat('2.10', 10); <2>
+parseFloat('2.10'); <2>
 ----
 <1> Retourne `2` ;
 <2> Retourne `2.10`.
+
+[TIP]
+.[RemarquePreTitre]#FAQ# Le second argument de parseInt
+====
+Le second argument de la fonction `parseInt` indique dans quelle base la valeur est représentée dans la chaîne. La base décimale (10) est la plus souvent utilisée, mais il est également possible de convertir une chaîne représentant un nombre binaire (base 2), ou héxadécimal (base 16).
+====
 
 La méthode `isNaN` permet d'être sûr de ne pas manipuler un nombre indésirable :
 


### PR DESCRIPTION
Ajout de l'explication du second argument de parseInt (ça peut servir pour les binaires et les hexa)
Suppression du second argument sur parseFloat qui n'existe pas.