### PR TITLE
Ajout ES6 dans explication spec ECMAScript ?

### DIFF
--- a/chapter-02/index.adoc
+++ b/chapter-02/index.adoc
@@ -569,7 +569,7 @@ image::images/compat-table.png[align="center",scaledwidth="85%"]
 ==== Standard ECMA-262 Edition 2015, 2016 etc.
 
 La spécification *ECMAScript 2015* (_ES2015_) a été publiée en juin 2015 et succède à *ECMAScript 5*. +
-La spécification _ES2015_ a successivement été appelée _ECMAScript Harmony_ puis _ECMAScript 2015_.
+La spécification _ES2015_ a successivement été appelée _ECMAScript Harmony_, _ECMAScript 6_, puis _ECMAScript 2015_.
 
 La page Web suivante référence l'état de l'implémentation d'ECMAScript 2015 ainsi que des versions ultérieures sur différentes plates-formes, dont Node :
 


### PR DESCRIPTION
Il faudrait peut être dire à quoi correspond ES6 car on le voit souvent dans les ressources proposées mais ce n'est pas clairement expliqué (si je ne me trompe pas, ES6 est aussi l'ancien nom de ES2015 ?)