### PR TITLE
Use Asciidoctor.js to build the book

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,30 +11,15 @@ VIDEO_FILES_DIST := $(VIDEO_FILES:%=$(BUILD_DIR)/%)
 clean:
 	rm -rf $(BUILD_DIR)
 
-install:
-	docker pull $(DOCKER_IMAGE)
-
 $(VIDEO_FILES_DIST): $(VIDEO_FILES)
 	@mkdir -p $(dir $@)
 	cp $< $@
 
 $(HTML_FILES): $(ADOC_FILES)
 	@mkdir -p $(dir $@)
-	$(DOCKER_COMMAND) \
-		-a data-uri \
-		-a toc=macro \
-		-a toclevels=4 \
-		-a icons=font \
-		-a lang=fr \
-		-a env=ci \
-		-a hide-uri-scheme \
-		-a docinfo1 \
-		-a experimental \
-		-D $(dir $@) \
-		-b html5 \
-		-d book $(@:dist/%.html=%.adoc)
 
 build-html: $(HTML_FILES) $(VIDEO_FILES_DIST)
+	node build.js
 
 deploy-html: $(VIDEO_FILES_DIST) $(HTML_FILES)
 	rm -rf /tmp/deploy && cp -r $(BUILD_DIR) /tmp/deploy
@@ -46,5 +31,5 @@ deploy-html: $(VIDEO_FILES_DIST) $(HTML_FILES)
           && git commit -am 'Build HTML book' \
           && git push -q -f origin gh-pages
 
-.PHONY: build-html clean deploy-html install
+.PHONY: build-html clean deploy-html
 .SILENT: deploy-html

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 BUILD_DIR=dist
 GIT_REPO=oncletom/nodebook
-DOCKER_IMAGE=oncletom/asciidoctor
-DOCKER_COMMAND=docker run -i --rm -v $(CURDIR):/documents $(DOCKER_IMAGE)
 
 ADOC_FILES = $(wildcard index.adoc chapter-*/index.adoc appendix-*/index.adoc foreword/*.adoc)
 HTML_FILES = $(ADOC_FILES:%.adoc=$(BUILD_DIR)/%.html)

--- a/build.js
+++ b/build.js
@@ -1,0 +1,39 @@
+'use strict'
+
+var fs = require('fs');
+var glob = require('glob');
+
+var removeSync = function(dir) {
+  var files = [];
+  if (fs.existsSync(dir)) {
+    files = fs.readdirSync(dir);
+    files.forEach(function(file){
+      var curPath = dir + '/' + file;
+      if (fs.lstatSync(curPath).isDirectory()) { // recurse
+        removeSync(curPath);
+      } else { // delete file
+        fs.unlinkSync(curPath);
+      }
+    });
+    fs.rmdirSync(dir);
+  }
+};
+
+var processor = require('asciidoctor.js')();
+var buildDir = 'dist';
+
+removeSync(buildDir);
+
+var defaultAttributes = ['data-uri', 'toc=macro', 'toclevels=4', 'icons=font', 'lang=fr', 'env=ci', 'hide-uri-scheme', 'experimental'];
+glob('{index.adoc,chapter-*/index.adoc,foreword/*.adoc,appendix-*/*.adoc}', function (err, files) {
+  if (err) {
+    console.error('Something went wrong!', err);
+    process.exit(1);
+  }
+  files.forEach(function(file) {
+    var destinationFile = file.replace('.adoc', '.html');
+    // FIXME: Add docinfo1 attribute when Asciidoctor.js will handle missing docinfo file correctly
+    var options = {'to_file': buildDir + '/' + destinationFile, 'mkdirs': true, 'safe': 'unsafe', 'backend': 'html5', 'doctype': 'book', 'attributes': defaultAttributes};
+    processor.convertFile(file, options);
+  });
+});

--- a/build.js
+++ b/build.js
@@ -1,28 +1,9 @@
 'use strict'
 
-var fs = require('fs');
 var glob = require('glob');
-
-var removeSync = function(dir) {
-  var files = [];
-  if (fs.existsSync(dir)) {
-    files = fs.readdirSync(dir);
-    files.forEach(function(file){
-      var curPath = dir + '/' + file;
-      if (fs.lstatSync(curPath).isDirectory()) { // recurse
-        removeSync(curPath);
-      } else { // delete file
-        fs.unlinkSync(curPath);
-      }
-    });
-    fs.rmdirSync(dir);
-  }
-};
 
 var processor = require('asciidoctor.js')();
 var buildDir = 'dist';
-
-removeSync(buildDir);
 
 var defaultAttributes = ['data-uri', 'toc=macro', 'toclevels=4', 'icons=font', 'lang=fr', 'env=ci', 'hide-uri-scheme', 'experimental'];
 glob('{index.adoc,chapter-*/index.adoc,foreword/*.adoc,appendix-*/*.adoc}', function (err, files) {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "husky": "^0.13.1",
     "prettier-eslint": "^3.0.2",
     "prettier-eslint-cli": "^1.1.0",
-    "serve-static": "^1.5.1"
+    "serve-static": "^1.5.1",
+    "asciidoctor.js": "1.5.5-4",
+    "glob": "7.1.1"
   },
   "eslintConfig": {
     "root": true,


### PR DESCRIPTION
#### Build procedure

```
npm install
node build.js
```

#### TODO

 * [x] Add Documentation
 * [ ] Upgrade to Opal 0.11 and Asciidoctor.js > 1.5.5-4 to resolve an issue when `'docinfo1'` attribute is set and the docinfo file is not found/missing