### PR TITLE
Correction d'un snippet

### DIFF
--- a/chapter-01/index.adoc
+++ b/chapter-01/index.adoc
@@ -456,13 +456,7 @@ L'exemple suivant illustre avec du code ce qu'est un module CommonJS.
 [source,javascript]
 .increment-module.js
 ----
-let privateValue = 0;
-
-module.exports = () => {
-  privateValue++;
-
-  return privateValue;
-};
+include::{sourceDir}/increment-module.js[]
 ----
 
 La spécification _Module_ de CommonJS fait usage de la portée lexicale (_lexical scope_) pour isoler ce qui appartient au module (la variable `privateValue`) et ce qu'il expose (une fonction incrémentant et retournant la variable privée).

--- a/chapter-01/index.adoc
+++ b/chapter-01/index.adoc
@@ -456,7 +456,7 @@ L'exemple suivant illustre avec du code ce qu'est un module CommonJS.
 [source,javascript]
 .increment-module.js
 ----
-const privateValue = 0;
+let privateValue = 0;
 
 module.exports = () => {
   privateValue++;


### PR DESCRIPTION
`privateValue++` est une assignation qui n'est pas compatible avec `*const* privateValue = 0`.

En tout cas, c'est beaucoup plus fluide à lire que la première fois que j'avais tenté de m'y mettre !
C'est chouette de voir l'évolution. Merci de l'avoir exposé sur github.