### PR TITLE
Toute petite correction : "nom" au lieu de "npm"

### DIFF
--- a/chapter-02/index.adoc
+++ b/chapter-02/index.adoc
@@ -3282,7 +3282,7 @@ Le tableau ne liste que les dépendances considérées comme obsolètes en l'ét
 Il se peut donc que le résultat varie d'une machine à l'autre, en fonction des versions installées localement. +
 Les résultats est divisé en cinq colonnes :
 
-- *Package* : npm du paquet concerné — en jaune une dépendance qui sera satisfaite en cas de `npm update`, en rouge une dépendance qui nécessite une mise à jour manuelle ;
+- *Package* : nom du paquet concerné — en jaune une dépendance qui sera satisfaite en cas de `npm update`, en rouge une dépendance qui nécessite une mise à jour manuelle ;
 - *Current* : version installée localement — _MISSING_ sera affiché si la dépendance n'est pas encore installée, _git_ indique que la dépendance est installée via git ;
 - *Wanted* : version installée après exécution de `npm update` ;
 - *Latest* : version la plus récente publiée dans le registre npm ;


### PR DESCRIPTION
Une petite coquille, j'imagine provoquée à force de parler beaucoup de "npm", un npm de trop s'est glissé dans le livre.

Merci pour ce projet de livre !
Voilà ma contribution de 1 caractère :-)