### PR TITLE
Correction du résultat de la regex '!(pug)'

### DIFF
--- a/chapter-02/index.adoc
+++ b/chapter-02/index.adoc
@@ -2422,7 +2422,7 @@ include::{sourceDir}/pattern/glob.js[]
 <1> fichiers débutant par `template` ;
 <2> fichiers débutant par `template` et suffixés par `hbs` ou dont le suffixe débute par `ej` ;
 <3> fichiers débutant par `template` et dont le suffixe est précédé par les lettres `e` ou `j` ;
-<4> fichiers débutant par `template`, à l'exception de `template.jade` ;
+<4> fichiers débutant par `template`, à l'exception de `template.pug` ;
 <5> fichiers contenus dans le répertoire `src` et suffixés par `css`, peu importe leur emplacement dans l'arborescence.
 
 [CAUTION]


### PR DESCRIPTION
la regex 'template.!(pug)'  => à l'exception de `template.pug`

de plus, il y a bien un `./appendix-a/examples/template.pug` mais pas de `template.jade` :
```
./appendix-a/examples/template.hbs
./appendix-a/examples/template.jsx
./appendix-a/examples/template.pug
./appendix-a/examples/template.swig
./appendix-a/examples/template.ejs
```