### PR TITLE
Correction d'un lien mort vers MDN dans le chapitre 03

### DIFF
--- a/chapter-03/index.adoc
+++ b/chapter-03/index.adoc
@@ -284,7 +284,7 @@ La valeur `undefined` est utilisée pour signifier
 qu'une *valeur est inconnue*.
 Rares sont les cas où on choisira ce type de données par nous-même.
 
-mdn::global[Data_structures, title="primitives"]
+mdn::javascript[Data_structures, title="primitives"]
 
 Il existe trois autres types de données qui se basent sur ces types
 dits _primitifs_.

--- a/src/asciidoctor-extension-mdn.js
+++ b/src/asciidoctor-extension-mdn.js
@@ -12,6 +12,7 @@ const fromHash = (hash) => {
 const lang = 'fr';
 const NAMESPACES = {
   addons: 'Add-ons/WebExtensions/API',
+  javascript: 'Web/JavaScript',
   global: 'Web/JavaScript/Reference/Global_Objects',
   reference: 'Web/JavaScript/Reference',
   web: 'Web/API',


### PR DESCRIPTION
[La page sur les structures de données](https://developer.mozilla.org/fr/docs/Web/JavaScript/Structures_de_données) de MDN n'étant pas sous Global_Objects, le lien était mort (ou invitait à créer une page pour les plus chanceux⋅ses) :).

J'ai pris le namespace qui me paraissait le plus pertinent mais pas de souci pour prendre un nom moins "risqué" que `javascript`.