### PR TITLE
Rendu des blocs de code avec Prism.js

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -6,6 +6,7 @@ const asciidoctor = require('asciidoctor.js')();
 const runnerExtension = require('asciidoctor-extension-interactive-runner');
 const microtypoExtension = require('../src/asciidoctor-microtypography-french.js');
 const bash$Extension = require('../src/asciidoctor-extension-bash-dollar.js');
+const prismExtension = require('../src/asciidoctor-extension-prism.js');
 const MDNExtension = require('../src/asciidoctor-extension-mdn.js');
 const hashScroll = require('../src/asciidoctor-toc-hash-scroll.js');
 const styles = require('../src/asciidoctor-opendocument-styles.js');
@@ -28,7 +29,7 @@ var DEFAULT_ATTRIBUTES = [
   'hide-uri-scheme',
   'experimental',
   'idprefix',
-  'source-highlighter=highlightjs',
+  'source-highlighter!',
   'toc-title=Table des matières',
   'appendix-caption=Annexe',
   'last-update-label=Dernière mise à jour',
@@ -49,6 +50,7 @@ const BUILD_DIR = 'dist';
 
 asciidoctor.LoggerManager.setLogger(memoryLogger);
 asciidoctor.Extensions.register(microtypoExtension);
+asciidoctor.Extensions.register(prismExtension);
 asciidoctor.Extensions.register(runnerExtension);
 asciidoctor.Extensions.register(bash$Extension);
 asciidoctor.Extensions.register(MDNExtension);

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
     },
     "ansi-escapes": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
       "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
@@ -365,7 +365,7 @@
     },
     "callsites": {
       "version": "0.2.0",
-      "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
@@ -463,6 +463,18 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
+    },
+    "clipboard": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.4.tgz",
+      "integrity": "sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
     },
     "cliui": {
       "version": "4.1.0",
@@ -661,6 +673,13 @@
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
       "dev": true
+    },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+      "dev": true,
+      "optional": true
     },
     "depd": {
       "version": "1.1.2",
@@ -1779,7 +1798,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "get-value": {
@@ -1827,6 +1846,16 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.9.0.tgz",
       "integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg==",
       "dev": true
+    },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "delegate": "^3.1.2"
+      }
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -2485,7 +2514,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -2494,7 +2523,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
@@ -2803,7 +2832,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -2926,6 +2955,15 @@
         "is-finite": "^1.0.1",
         "parse-ms": "^1.0.0",
         "plur": "^1.0.0"
+      }
+    },
+    "prismjs": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.15.0.tgz",
+      "integrity": "sha512-Lf2JrFYx8FanHrjoV5oL8YHCclLQgbJcVZR+gikGGMqz6ub5QVWDTM6YIwm3BuPxM/LOV+rKns3LssXNLIf+DA==",
+      "dev": true,
+      "requires": {
+        "clipboard": "^2.0.0"
       }
     },
     "process-nextick-args": {
@@ -3068,7 +3106,7 @@
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
@@ -3159,6 +3197,13 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
+      "dev": true,
+      "optional": true
     },
     "semver": {
       "version": "5.6.0",
@@ -3523,7 +3568,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-json-comments": {
@@ -3707,6 +3752,13 @@
         "readable-stream": "^2.1.5",
         "xtend": "~4.0.1"
       }
+    },
+    "tiny-emitter": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.2.tgz",
+      "integrity": "sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow==",
+      "dev": true,
+      "optional": true
     },
     "tmp": {
       "version": "0.0.33",
@@ -3941,7 +3993,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "eslint": "^5.9.0",
     "eslint-plugin-react": "^7.11.1",
     "ora": "^3.0.0",
+    "prismjs": "^1.15.0",
     "tap-spec": "^5.0.0",
     "tape-spawn": "^1.4.2"
   },

--- a/src/asciidoctor-extension-prism.js
+++ b/src/asciidoctor-extension-prism.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const {readFileSync} = require('fs');
+const {join, dirname} = require('path');
+const Prism = require('prismjs');
+const loadLanguages = require('prismjs/components/index.js');
+
+// css, markup (html, xml, css, svg) and javascript are loaded by default
+const DEFAULT_LANGUAGES = [
+  'apacheconf',
+  'bash',
+  'docker',
+  'http',
+  'json',
+  'jsx',
+  'less',
+  'markdown',
+  'nginx',
+  'properties',
+  'sass',
+  'scss',
+  'typescript',
+  'tsx',
+  'yaml',
+];
+
+const hasLanguage = (block) => block.getAttribute('language');
+
+module.exports = function prismExtension (languages=DEFAULT_LANGUAGES, theme='prism.css') {
+  loadLanguages(languages);
+
+  Prism.languages.yml = Prism.languages.yaml;
+
+  Prism.hooks.add('before-tokenize', (env) => {
+    env.code = env.code.replace(/<b class="conum">\((\d+)\)<\/b>/gi, '____$1____');
+  });
+
+  const unescape = html => {
+    return html.replace(/=&gt;/gi, '=>')
+      .replace(/&lt;/gi, '<')
+      .replace(/&gt;/gi, '>');
+  }
+
+  this.treeProcessor(function(){
+    this.process(doc => {
+      if (doc.backend !== 'html5') {
+        return doc;
+      }
+
+      doc.findBy({ context: 'listing' }, hasLanguage).forEach(block => {
+        const lang = block.getAttribute('language');
+
+        if (Prism.languages[lang] === undefined) {
+          throw Error(`Prism language conversion failed; tried ${lang} (loaded: ${languages})`);
+        }
+
+        const output = Prism.highlight(unescape(block.getContent()), Prism.languages[lang]);
+        block.lines = output.replace(/____(\d+)____/gi, '<b class="conum">($1)</b>').split('\n');
+        block.removeSubstitution('specialcharacters');
+        block.removeSubstitution('specialchars');
+        block.addRole('prismjs');
+        block.addRole('highlight-prismjs');
+      });
+    });
+  });
+
+  this.docinfoProcessor(function(){
+    this.process(({backend}) => {
+      if (backend !== 'html5') {
+        return '';
+      }
+
+      const prism_folder = dirname(require.resolve('prismjs'));
+      const theme_location = join(prism_folder, 'themes', theme);
+      const output = readFileSync(theme_location);
+
+      return `<style type="text/css" class="prism-theme">${output}</style>`;
+    });
+  });
+};

--- a/src/book.css
+++ b/src/book.css
@@ -167,10 +167,11 @@ td.hdlist1 {
   .colist ol p {
     margin: 0 0 .5em;
   }
-.listingblock pre:not(.hljs),
+.listingblock:not(.prismjs) pre,
 .language-bash.hljs {
   background: #323232;
   color: wheat;
+  margin: 0;
   padding: 1rem;
 }
 .language-bash.hljs .hljs-built_in,
@@ -198,13 +199,17 @@ td.hdlist1 {
   font-weight: bold;
   padding: 0.1em 0.4em;
 }
-.listingblock pre.highlightjs {
+.listingblock pre.highlightjs,
+.listingblock.prismjs pre {
+  background-color: transparent;
   margin: 0;
   padding: 0;
 }
-.listingblock pre.highlightjs > code {
-  border: 1px solid var(--light-accent);
-  border-left-width: 4px;
+.listingblock pre.highlightjs > code,
+.listingblock.prismjs .highlight {
+  border-left: 4px solid var(--dark-accent);
+  padding-left: 1em;
+  font-size: .8em;
 }
 .listingblock pre.highlightjs > code.language-bash {
   border-left-color: limegreen;


### PR DESCRIPTION
En pri(s)me, le rendu est fait pendant la génération du HTML.
Auparavant, c'était fait côté client et ça nécessitait de charger des CSS et JS supplémentaires.

Activé aussi pour : 
- Dockerfile
- JSX/TSX
- TypeScript

fix #280 