### PR TITLE
Typo : balisage/indentation des listes imbriquées

### DIFF
--- a/chapter-02/index.adoc
+++ b/chapter-02/index.adoc
@@ -931,15 +931,16 @@ les prochaines versions et l'arrêt de maintenance des plus anciennes.
 
 Si on récapitule :
 indexterm:[version sémantique]
-- Les versions *impaires* (v5,{nbsp}v7,{nbsp}etc.)
-  - sont développées pendant _neuf mois_ ;
-  - ne sont pas maintenues au-delà.
-- Les versions *paires* (_LTS_,{nbsp}{nodeCurrentversion},{nbsp}etc.)
-  - sont basées sur la version _impaire_ précédente ;
-  - sont développées pendant _six{nbsp}mois_ ;
-  - sont maintenues LTS pendant _dix-huit{nbsp}mois_ ;
-  - basculent en maintenance pendant _douze{nbsp}mois_ supplémentaires ;
-  - ne sont pas maintenues au-delà.
+
+* Les versions *impaires* (v5,{nbsp}v7,{nbsp}etc.)
+** sont développées pendant _neuf mois_ ;
+** ne sont pas maintenues au-delà.
+* Les versions *paires* (_LTS_,{nbsp}{nodeCurrentversion},{nbsp}etc.)
+** sont basées sur la version _impaire_ précédente ;
+** sont développées pendant _six{nbsp}mois_ ;
+** sont maintenues LTS pendant _dix-huit{nbsp}mois_ ;
+** basculent en maintenance pendant _douze{nbsp}mois_ supplémentaires ;
+** ne sont pas maintenues au-delà.
 
 Les patchs de sécurité ne concernent que les versions en _développement_,
 _LTS_ ou en _maintenance_.


### PR DESCRIPTION
Je pense que l'intention originelle était d'avoir une liste sur deux niveaux pour la présentation. J'ai voulu conserver les tirets afin de moins m'écarter du style habituel mais [AsciiDoc n'en veut pas pour les listes imbriquées](https://asciidoctor.org/docs/asciidoc-writers-guide/#lists-of-things).